### PR TITLE
fix: show only date for announcements

### DIFF
--- a/server/getAnnouncements.ts
+++ b/server/getAnnouncements.ts
@@ -55,7 +55,7 @@ export const getAnnouncements = async (options?: GetAnnouncementsOptions) => {
     .map((item) => ({
       ...item,
       created: item.created?.toDate?.().toLocaleString() || null,
-      updated: item.updated?.toDate?.().toLocaleString() || null,
+      updated: item.updated?.toDate?.().toLocaleDateString() || null,
     })) as Announcement[];
 
   return { data: announcements, totalPages };

--- a/server/getAnnouncements.ts
+++ b/server/getAnnouncements.ts
@@ -54,7 +54,7 @@ export const getAnnouncements = async (options?: GetAnnouncementsOptions) => {
     })
     .map((item) => ({
       ...item,
-      created: item.created?.toDate?.().toLocaleString() || null,
+      created: item.created?.toDate?.().toLocaleDateString() || null,
       updated: item.updated?.toDate?.().toLocaleDateString() || null,
     })) as Announcement[];
 


### PR DESCRIPTION
Fix #20 

Changed toLocaleString into toLacaleDateString in getAnnouncements.ts to show only the date in announcements.